### PR TITLE
eliminated gifs from dailies

### DIFF
--- a/app/models/daily.rb
+++ b/app/models/daily.rb
@@ -4,8 +4,7 @@ class Daily
               :summary,
               :chance_of_precipitation,
               :temperature_high,
-              :temperature_low,
-              :gif_url
+              :temperature_low
 
   def initialize(daily_in)
     @day_of_week             = daily_in[:time]
@@ -13,12 +12,6 @@ class Daily
     @chance_of_precipitation = daily_in[:precipProbability]
     @temperature_high        = daily_in[:temperatureHigh]
     @temperature_low         = daily_in[:temperatureLow]
-    @gif_url                 = get_gif(daily_in[:summary])
-  end
-
-  def get_gif(summary)
-    gif_info = GiffyService.new(summary)
-    gif_info.url
   end
 
 end

--- a/app/models/forecast.rb
+++ b/app/models/forecast.rb
@@ -16,6 +16,7 @@ class Forecast
               :humidity,
               :visibility,
               :uv_index,
+              :gif_url,
               :hourlies,
               :dailies
 
@@ -37,6 +38,7 @@ class Forecast
     @humidity       = data[:currently][:humidity]
     @visibility     = data[:currently][:visibility]
     @uv_index       = data[:currently][:uvIndex]
+    @gif_url        = get_gif(data[:currently][:summary])
     @hourlies       = get_hourlies(data)
     @dailies        = get_dailies(data)
 
@@ -55,6 +57,11 @@ class Forecast
   end
 
 private
+
+  def get_gif(summary)
+    gif_info = GiffyService.new(summary)
+    gif_info.url
+  end
 
   def get_data(city_state)
     location = BingService.new(city_state)

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -16,6 +16,7 @@ class ForecastSerializer
               :humidity,
               :visibility,
               :uv_index,
+              :gif_url,
               :hourlies,
               :dailies
 

--- a/spec/models/forecast_spec.rb
+++ b/spec/models/forecast_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Forecast, type: :model do
+  it 'exists' do
+    location = 'denver,co'
+    forecast = Forecast.new(location)
+
+    expect(forecast).to be_a(Forecast)
+
+  end
+end

--- a/spec/requests/api/v1/favorites_endpoint_spec.rb
+++ b/spec/requests/api/v1/favorites_endpoint_spec.rb
@@ -22,7 +22,6 @@ describe 'the favorites endpoint' do
       expect(attrib[:current_weather].keys.include?(:chance_of_precipitation)).to be(true)
       expect(attrib[:current_weather].keys.include?(:temperature_high)).to be(true)
       expect(attrib[:current_weather].keys.include?(:temperature_low)).to be(true)
-      expect(attrib[:current_weather].keys.include?(:gif_url)).to be(true)
 
     end
   end

--- a/spec/requests/api/v1/forecast_endpoint_spec.rb
+++ b/spec/requests/api/v1/forecast_endpoint_spec.rb
@@ -10,6 +10,7 @@ describe 'the forecast endpoint' do
       expect(result[:data][:attributes]).not_to be_empty
       expect(result[:data][:attributes].keys.include?(:summary)).to be(true)
       expect(result[:data][:attributes].keys.include?(:city_state)).to be(true)
+      expect(result[:data][:attributes].keys.include?(:gif_url)).to be(true)
       expect(result[:data][:attributes][:hourlies].count).to eq(8)
       expect(result[:data][:attributes][:dailies].count).to eq(5)
     end
@@ -24,6 +25,7 @@ describe 'the forecast endpoint' do
       expect(result[:data][:attributes]).not_to be_empty
       expect(result[:data][:attributes].keys.include?(:summary)).to be(true)
       expect(result[:data][:attributes].keys.include?(:city_state)).to be(true)
+      expect(result[:data][:attributes].keys.include?(:gif_url)).to be(true)
       expect(result[:data][:attributes][:hourlies].count).to eq(8)
       expect(result[:data][:attributes][:dailies].count).to eq(5)
     end
@@ -38,10 +40,10 @@ describe 'the forecast endpoint' do
       expect(result[:data][:attributes]).not_to be_empty
       expect(result[:data][:attributes].keys.include?(:summary)).to be(true)
       expect(result[:data][:attributes].keys.include?(:city_state)).to be(true)
+      expect(result[:data][:attributes].keys.include?(:gif_url)).to be(true)
       expect(result[:data][:attributes][:hourlies].count).to eq(8)
       expect(result[:data][:attributes][:dailies].count).to eq(5)
     end
   end
-
 
 end


### PR DESCRIPTION
Daily forecasts (all five of them for each call for a location forecast!) were doing individual Giffy API calls. This took a lot of time and isn't necessary - I've decided to only supply a GIF for the current conditions. Should greatly speed up the location forecast API call.